### PR TITLE
chore(deps): bump deps; update to glium 0.17.0; fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+and this project (tries to!) adhere to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- bumped `glium`, `image`, and `lazy_static`
+- updated examples for `glium` `0.17.0`
+- cargo fmt
 
 ### Removed
 - *breaking* removed `units`, `mvp`, and `utils` from public interface

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ OpenGL-based tile rendering engine
 """
 
 [dependencies]
-glium = "0.16.0"
-image = "0.12.3"
-lazy_static = "0.2.2"
+glium = "0.17.0"
+image = "0.14.0"
+lazy_static = "0.2.8"
 palette = "0.2.1"
 pixset = "0.0.2"
 

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -7,7 +7,6 @@ extern crate glium;
 extern crate gltile;
 extern crate looper;
 
-use glium::DisplayBuild;
 use pixset::PixLike;
 
 pix! {
@@ -27,16 +26,14 @@ pix! {
 
 fn render_tile(renderer: &mut gltile::Renderer, loc: (i32, i32), pix: Pix) {
     let tile = gltile::Tile::make(*gltile::colors::YELLOW, *gltile::colors::BLACK, pix);
-
     renderer.set(loc, tile);
 }
 
 fn main() {
-    let display = glium::glutin::WindowBuilder::new()
-        .with_dimensions(512, 512)
-        .build_glium()
-        .unwrap();
-
+    let mut events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new().with_dimensions(512, 512);
+    let context = glium::glutin::ContextBuilder::new();
+    let display = glium::Display::new(window, context, &events_loop).unwrap();
     let mut renderer = gltile::Renderer::new(&display, TILESET, Pix::Empty);
 
     render_tile(&mut renderer, (5, 5), Pix::One);
@@ -54,14 +51,20 @@ fn main() {
         looper::Action::Continue
     };
 
+
     let update = |_| {
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return looper::Action::Stop,
-                _ => (),
+        let mut action = looper::Action::Continue;
+        events_loop.poll_events(|event| match event {
+            glium::glutin::Event::WindowEvent { event, .. } => {
+                match event {
+                    glium::glutin::WindowEvent::Closed => action = looper::Action::Stop,
+                    _ => (),
+                }
             }
-        }
-        looper::Action::Continue
+            _ => (),
+        });
+
+        action
     };
 
     looper::Looper::new(60.0).run(render, update);

--- a/examples/dood.rs
+++ b/examples/dood.rs
@@ -3,14 +3,11 @@ extern crate gltile;
 extern crate looper;
 extern crate pixset;
 
-use glium::DisplayBuild;
-
 fn main() {
-    let display = glium::glutin::WindowBuilder::new()
-        .with_dimensions(512, 512)
-        .build_glium()
-        .unwrap();
-
+    let mut events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new().with_dimensions(512, 512);
+    let context = glium::glutin::ContextBuilder::new();
+    let display = glium::Display::new(window, context, &events_loop).unwrap();
     let mut renderer = gltile::Renderer::new(&display, pixset::TILESET, pixset::Pix::Empty);
 
     let tile = gltile::Tile::make(
@@ -27,13 +24,18 @@ fn main() {
     };
 
     let update = |_| {
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return looper::Action::Stop,
-                _ => (),
+        let mut action = looper::Action::Continue;
+        events_loop.poll_events(|event| match event {
+            glium::glutin::Event::WindowEvent { event, .. } => {
+                match event {
+                    glium::glutin::WindowEvent::Closed => action = looper::Action::Stop,
+                    _ => (),
+                }
             }
-        }
-        looper::Action::Continue
+            _ => (),
+        });
+
+        action
     };
 
     looper::Looper::new(60.0).run(render, update);

--- a/examples/non_square_2.rs
+++ b/examples/non_square_2.rs
@@ -7,7 +7,6 @@ extern crate glium;
 extern crate gltile;
 extern crate looper;
 
-use glium::DisplayBuild;
 use pixset::PixLike;
 
 pix! {
@@ -32,11 +31,10 @@ fn render_tile(renderer: &mut gltile::Renderer, loc: (i32, i32), pix: Pix) {
 }
 
 fn main() {
-    let display = glium::glutin::WindowBuilder::new()
-        .with_dimensions(768, 512)
-        .build_glium()
-        .unwrap();
-
+    let mut events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new().with_dimensions(768, 512);
+    let context = glium::glutin::ContextBuilder::new();
+    let display = glium::Display::new(window, context, &events_loop).unwrap();
     let mut renderer = gltile::Renderer::new(&display, TILESET, Pix::Empty);
 
     render_tile(&mut renderer, (5, 5), Pix::One);
@@ -55,13 +53,18 @@ fn main() {
     };
 
     let update = |_| {
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return looper::Action::Stop,
-                _ => (),
+        let mut action = looper::Action::Continue;
+        events_loop.poll_events(|event| match event {
+            glium::glutin::Event::WindowEvent { event, .. } => {
+                match event {
+                    glium::glutin::WindowEvent::Closed => action = looper::Action::Stop,
+                    _ => (),
+                }
             }
-        }
-        looper::Action::Continue
+            _ => (),
+        });
+
+        action
     };
 
     looper::Looper::new(60.0).run(render, update);

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -3,14 +3,11 @@ extern crate gltile;
 extern crate looper;
 extern crate pixset;
 
-use glium::DisplayBuild;
-
 fn main() {
-    let display = glium::glutin::WindowBuilder::new()
-        .with_dimensions(512, 512)
-        .build_glium()
-        .unwrap();
-
+    let mut events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new().with_dimensions(512, 512);
+    let context = glium::glutin::ContextBuilder::new();
+    let display = glium::Display::new(window, context, &events_loop).unwrap();
     let mut renderer = gltile::Renderer::new(&display, pixset::TILESET, pixset::Pix::Empty);
 
     for (pix, offset) in pixset::PixStr::from("Yo, Dawg;").iter() {
@@ -24,13 +21,18 @@ fn main() {
     };
 
     let update = |_| {
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return looper::Action::Stop,
-                _ => (),
+        let mut action = looper::Action::Continue;
+        events_loop.poll_events(|event| match event {
+            glium::glutin::Event::WindowEvent { event, .. } => {
+                match event {
+                    glium::glutin::WindowEvent::Closed => action = looper::Action::Stop,
+                    _ => (),
+                }
             }
-        }
-        looper::Action::Continue
+            _ => (),
+        });
+
+        action
     };
 
     looper::Looper::new(60.0).run(render, update);

--- a/src/vertex/vertex_data.rs
+++ b/src/vertex/vertex_data.rs
@@ -16,7 +16,10 @@ impl VertexData {
         let mut data: Vec<vertex::Vertex> = Vec::with_capacity(length * 4);
 
         for i in 0..length {
-            let (x, y) = (i as i32 % size.width, size.height - 1 - i as i32 / size.width as i32);
+            let (x, y) = (
+                i as i32 % size.width,
+                size.height - 1 - i as i32 / size.width as i32,
+            );
             data.push(vertex::Vertex::new([-0.5, 0.5], [left, top], [x, y + 1]));
             data.push(vertex::Vertex::new(
                 [0.5, 0.5],


### PR DESCRIPTION
`glium` `0.17.0` contains a pretty [large refactor of `glutin`](https://github.com/tomaka/glutin/pull/901) so this PR updates `gltile` to use the new initialization sequence in all the examples. A future PR is needed to reduce boilerplate of both the initialization of the `renderer` and the event loop. The event loop should be handled in `looper` if at all possible.

Other PRs:
https://github.com/glium/glium/pull/1601
https://github.com/tomaka/winit/pull/126